### PR TITLE
Prevent privilege escalations through invalid JWTs

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -313,9 +313,9 @@ func (r *oauthProxy) loginHandler(w http.ResponseWriter, req *http.Request) {
 func emptyHandler(w http.ResponseWriter, req *http.Request) {}
 
 // logoutHandler performs a logout
-//  - if it's just a access token, the cookie is deleted
-//  - if the user has a refresh token, the token is invalidated by the provider
-//  - optionally, the user can be redirected by to a url
+//   - if it's just a access token, the cookie is deleted
+//   - if the user has a refresh token, the token is invalidated by the provider
+//   - optionally, the user can be redirected by to a url
 func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 	// @check if the redirection is there
 	var redirectURL string
@@ -330,7 +330,7 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// @step: drop the access token
-	user, err := r.getIdentity(req)
+	user, err := r.getIdentityFromRequest(req)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -434,7 +434,7 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 
 // expirationHandler checks if the token has expired
 func (r *oauthProxy) expirationHandler(w http.ResponseWriter, req *http.Request) {
-	user, err := r.getIdentity(req)
+	user, err := r.getIdentityFromRequest(req)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		return
@@ -449,7 +449,7 @@ func (r *oauthProxy) expirationHandler(w http.ResponseWriter, req *http.Request)
 
 // tokenHandler display access token to screen
 func (r *oauthProxy) tokenHandler(w http.ResponseWriter, req *http.Request) {
-	user, err := r.getIdentity(req)
+	user, err := r.getIdentityFromRequest(req)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/middleware.go
+++ b/middleware.go
@@ -321,6 +321,7 @@ func (r *oauthProxy) authenticationMiddleware() func(http.Handler) http.Handler 
 						next.ServeHTTP(w, req.WithContext(r.redirectToAuthorization(w, req)))
 						return
 					}
+					scope.Identity = user
 					ctx = context.WithValue(req.Context(), contextScopeName, scope)
 				}
 			}

--- a/oauth.go
+++ b/oauth.go
@@ -32,7 +32,7 @@ import (
 	"github.com/coreos/go-oidc/oidc"
 )
 
-//FIXME remove constants in the future which hopefully won't be necessary in the next releases
+// FIXME remove constants in the future which hopefully won't be necessary in the next releases
 const (
 	GrantTypeAuthCode     = "authorization_code"
 	GrantTypeUserCreds    = "password"

--- a/session_test.go
+++ b/session_test.go
@@ -62,7 +62,7 @@ func TestGetIndentity(t *testing.T) {
 	}
 
 	for i, c := range testCases {
-		user, err := p.getIdentity(c.Request)
+		user, err := p.getIdentityFromRequest(c.Request)
 		if err != nil && c.Ok {
 			t.Errorf("test case %d should not have errored", i)
 			continue

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/net/websocket"
 )
 
-//TestWebSocket is used to validate that the proxy reverse proxy WebSocket connections.
+// TestWebSocket is used to validate that the proxy reverse proxy WebSocket connections.
 func TestWebSocket(t *testing.T) {
 	// Setup an upstream service.
 	upstream := &fakeUpstreamService{}


### PR DESCRIPTION
Louketo has a bug revolving around this PR: https://github.com/coreos/go-oidc/pull/97
Essentially, the JWT verification function first checks the claims of the JWT are valid (including expiry times), then checks the signature of the token is valid.
Louketo [checks the response of this](https://github.com/signal-ai/louketo-proxy/blob/dae8880bdc2aa2e9c9fa56c830b6353aec338d79/oauth.go#L60-L67) and returns a custom error if the token has expired to allow the auth middleware to [use a refresh token to regenerate an access token](https://github.com/signal-ai/louketo-proxy/blob/dae8880bdc2aa2e9c9fa56c830b6353aec338d79/middleware.go#L197-L199).
Unfortunately, the access token it generates uses the [user context](https://github.com/signal-ai/louketo-proxy/blob/dae8880bdc2aa2e9c9fa56c830b6353aec338d79/middleware.go#L171-L172) for the incoming request. This user context is [parsed from the access token JWT](https://github.com/signal-ai/louketo-proxy/blob/dae8880bdc2aa2e9c9fa56c830b6353aec338d79/session.go#L41-L48) but is not verified, meaning it is blindly trusted. If this payload is manipulated, it will be accepted even if the signature is not valid.
Louketo will then [regenerate a correct accessToken from Keycloak](https://github.com/signal-ai/louketo-proxy/blob/dae8880bdc2aa2e9c9fa56c830b6353aec338d79/middleware.go#L245), which will be valid and have the correct claim/scopes as generated in Keycloak. I think the issue is that for the rest of the request, it [has this new token in the context](https://github.com/signal-ai/louketo-proxy/blob/dae8880bdc2aa2e9c9fa56c830b6353aec338d79/middleware.go#L318) but still has the leftover rubbish user context parsed from the fake user we injected earlier.

This PR explicitly resets the auth middleware's representation of the desired user by reading it from the token regenerated in Keycloak, the source of truth, after a token is refreshed, rather than assuming anything about the user identity.